### PR TITLE
Fix memory leak in AppChannels: free hint_hl_ctx in onDestroy

### DIFF
--- a/main/apps/app_channels/app_channels.cpp
+++ b/main/apps/app_channels/app_channels.cpp
@@ -274,7 +274,11 @@ void AppChannels::onRunning()
     }
 }
 
-void AppChannels::onDestroy() { UTILS::SCROLL_TEXT::scroll_text_free(&_data.desc_scroll_ctx); }
+void AppChannels::onDestroy()
+{
+    UTILS::SCROLL_TEXT::scroll_text_free(&_data.desc_scroll_ctx);
+    UTILS::HL_TEXT::hl_text_free(&_data.hint_hl_ctx);
+}
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
I noticed every time I open and close a "Channels" screen,
heap gets lower around 6KB even without opening an actual channel and never gets back.

adding this line should free LGFX-related memory and fix the issue,
also it's only App's code that doesn't have this line in `onDestryoy()` as far as I grep'd, so it should be okay.

i've tested both on your main branch and my fork, happy to report that i've confirmed the issue is fixed on both build.

hope this helps you and others! (by the way, this might be the my very first PR on github)